### PR TITLE
Allow multiple selects and add 'step' to number field formbuilder support

### DIFF
--- a/dynamic_forms/utils.py
+++ b/dynamic_forms/utils.py
@@ -25,7 +25,8 @@ def _process_hidden(field_json):
 def _process_number(field_json):
     return forms.FloatField(
         min_value=field_json.get("min", None),
-        max_value=field_json.get("max", None)
+        max_value=field_json.get("max", None),
+        widget=forms.NumberInput(attrs={'step': field_json.get("step", "any")})
     )
 
 


### PR DESCRIPTION
Support multiple selects by checking formbuilder JSON for 'multiple' prop set to true, using Django's `MultipleChoiceField`.  

Support 'step' argument for number fields in formbuilder using Django's `FloatField` `widget` property. [see here](https://code.djangoproject.com/ticket/32559)