### PR TITLE
Don't show text like <p>None</p>

### DIFF
--- a/dynamic_forms/templates/dynamic_forms/widgets/subfield.html
+++ b/dynamic_forms/templates/dynamic_forms/widgets/subfield.html
@@ -1,3 +1,5 @@
 {{label}}
 {{field}}
+{% if help_text is not None %}
 <p>{{help_text}}</p>
+{% endif %}

--- a/dynamic_forms/utils.py
+++ b/dynamic_forms/utils.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.html import strip_tags
 from .forms import HTMLField
 from .widgets import HTMLFieldWidget
 
@@ -94,7 +95,7 @@ def process_field_from_json(field_json):
     field_type = field_json['type']
     common_field_attrs = {
         'required': field_json.get('required', False),
-        'label': field_json.get('label', None),
+        'label': strip_tags(field_json.get('label', None)),
         'initial': field_json.get('value', None),
         'help_text': field_json.get('description', None),
     }


### PR DESCRIPTION
![immagine](https://user-images.githubusercontent.com/403283/152554458-7196a684-6b83-46ad-a3e9-63860cd1fccf.png)

This patch should avoid to print None like in the screen but I didn't tested.
~~I have to see how to remove that '< br>' from the field name.~~

Done also that part